### PR TITLE
sales engine now creates hash with values that are arrays of instances

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -3,13 +3,15 @@ require 'bigdecimal'
 
 class Item
 
-  attr_reader :name,
+  attr_reader :id,
+              :name,
               :description,
               :unit_price,
               :created_at,
               :updated_at
 
   def initialize(hash)
+    @id = hash[:id]
     @name = hash[:name]
     @description = hash[:description]
     @unit_price = hash[:unit_price]
@@ -18,7 +20,7 @@ class Item
   end
 
   def unit_price_to_dollars
-    self.unit_price.to_f
+    (self.unit_price.to_f)/100
   end
 
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -1,16 +1,18 @@
 require 'pry'
 require 'csv'
+require_relative 'merchant'
+require_relative 'item'
 
 class SalesEngine
 
   def from_csv(hash)
-    items_array = items_array_maker(hash[:items])
-    merchants_array = merchants_array_maker(hash[:merchants])
+    items_array = item_instance_maker(hash[:items])
+    merchants_array = merchant_instance_maker(hash[:merchants])
     sales_engine_hash = {:items => items_array,
                          :merchants => merchants_array}
   end
 
-  def items_array_maker(items_filepath)
+  def item_instance_maker(items_filepath)
     contents = CSV.open items_filepath, headers: true, header_converters: :symbol
     items = []
     contents.each do |row|
@@ -22,12 +24,12 @@ class SalesEngine
       hash[:merchant_id] = row[:merchant_id]
       hash[:created_at] = row[:created_at]
       hash[:updated_at] = row[:updated_at]
-      items << hash
+      items << Item.new(hash)
     end
     items
   end
 
-  def merchants_array_maker(merchants_filepath)
+  def merchant_instance_maker(merchants_filepath)
     contents = CSV.open merchants_filepath, headers: true, header_converters: :symbol
     merchants = []
     contents.each do |row|
@@ -36,7 +38,7 @@ class SalesEngine
       hash[:name] = row[:name]
       hash[:created_at] = row[:created_at]
       hash[:updated_at] = row[:updated_at]
-      merchants << hash
+      merchants << Merchant.new(hash)
     end
     merchants
   end

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -16,28 +16,19 @@ class SalesEngineTest < Minitest::Test
     assert_equal Hash, @result.class
   end
 
-  def test_can_get_item_names_and_merchant_names
-    item_names_array = @result[:items].map do |hash|
-      hash[:name]
-    end
-    merchant_names_array = @result[:merchants].map do |hash|
-      hash[:name]
-    end
+  def test_sales_engine_hash_contains_item_and_merchant_instances
+    assert_equal Item, @result[:items].first.class
+    assert_equal Merchant, @result[:merchants].first.class
+  end
 
-    assert_equal "Minty Green Knit Crochet Infinity Scarf", item_names_array.last
-    assert_equal "CJsDecor", merchant_names_array.last
+  def test_can_get_item_names_and_merchant_names
+    assert_equal "Minty Green Knit Crochet Infinity Scarf", @result[:items].last.name
+    assert_equal "CJsDecor", @result[:merchants].last.name
   end
 
   def test_from_csv_outputs_item_ids_and_merchant_ids
-    item_ids_array = @result[:items].map do |hash|
-      hash[:id]
-    end
-    merchant_ids_array = @result[:merchants].map do |hash|
-      hash[:id]
-    end
-
-    assert_equal "263567474", item_ids_array.last
-    assert_equal "12337411", merchant_ids_array.last
+    assert_equal "263567474", @result[:items].last.id
+    assert_equal "12337411", @result[:merchants].last.id
   end
 
 end


### PR DESCRIPTION
This modifies sales engine so that it now takes the two csv files files and creates values for the keys :items and :merchants that are an array filled with item and merchant instances.
