### PR TITLE
first half of relationships layer for iteration 1 working

### DIFF
--- a/lib/items_by_merchant_searcher.rb
+++ b/lib/items_by_merchant_searcher.rb
@@ -1,0 +1,25 @@
+require 'pry'
+require_relative 'item_repository'
+require_relative 'merchant'
+
+class ItemsByMerchantSearcher
+
+  attr_reader :merchants_items
+
+  def initialize(merchant_id, items_in_sales_engine)
+    @merchant_id = merchant_id
+    @items_in_sales_engine = items_in_sales_engine
+    find_merchants_items
+  end
+
+  def self.push_items(merchant_id, items_in_sales_engine)
+    ItemsByMerchantSearcher.new(merchant_id, items_in_sales_engine)
+  end
+
+  def find_merchants_items
+    item_repository = ItemRepository.new(@items_in_sales_engine)
+    @merchants_items = item_repository.find_all_by_merchant_id(@merchant_id)
+    Merchant.push_items_to_merchant(@merchants_items)
+  end
+
+end

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -1,4 +1,7 @@
 require 'pry'
+require_relative 'item_repository'
+require_relative 'items_by_merchant_searcher'
+require_relative 'sales_engine'
 
 class Merchant
 
@@ -7,6 +10,19 @@ class Merchant
   def initialize(hash)
     @id = hash[:id].to_i
     @name = hash[:name]
+  end
+
+  def items
+    SalesEngine.push_to_merchant_searcher(self.id)
+    Merchant.items_being_sold
+  end
+
+  def self.push_items_to_merchant(items)
+    @merchants_items_being_sold = items
+  end
+
+  def self.items_being_sold
+    @merchants_items_being_sold
   end
 
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -2,8 +2,12 @@ require 'pry'
 require 'csv'
 require_relative 'merchant'
 require_relative 'item'
+require_relative 'item_repository'
+require_relative 'merchant_repository'
 
 class SalesEngine
+
+  attr_reader :sales_engine_hash
 
   def initialize(hash)
     @items = hash[:items]
@@ -13,8 +17,8 @@ class SalesEngine
   def self.from_csv(hash)
     items_array = item_instance_maker(hash[:items])
     merchants_array = merchant_instance_maker(hash[:merchants])
-    hash = {:items => items_array, :merchants => merchants_array}
-    SalesEngine.new(hash)
+    @sales_engine_hash = {:items => items_array, :merchants => merchants_array}
+    SalesEngine.new(@sales_engine_hash)
   end
 
   def items
@@ -23,6 +27,11 @@ class SalesEngine
 
   def merchants
     MerchantRepository.new(@merchants)
+  end
+
+  def self.push_to_merchant_searcher(merchant_instance_id)
+    ItemsByMerchantSearcher.push_items(merchant_instance_id,
+                                       @sales_engine_hash[:items])
   end
 
   def self.item_instance_maker(items_filepath)

--- a/test/items_by_merchant_searcher_test.rb
+++ b/test/items_by_merchant_searcher_test.rb
@@ -1,0 +1,27 @@
+require 'minitest/autorun'
+require 'pry'
+require_relative '../lib/items_by_merchant_searcher'
+require_relative '../lib/item'
+
+class ItemsByMerchantSearcherTest < Minitest::Test
+
+  def setup
+    @item_1 = Item.new({id: 263395237,
+                       name: "510+ RealPush Icon Set",
+                       merchant_id: 12334141})
+    item_2 = Item.new({id: 342395237,
+                       name: "chocolate",
+                       merchant_id: 2342141})
+    @item_3 = Item.new({id: 543395237,
+                       name: "pullup bar",
+                       merchant_id: 12334141})
+    @item_array = [@item_1, item_2, @item_3]
+  end
+
+  def test_can_look_up_a_merchants_items_in_itself
+    searcher = ItemsByMerchantSearcher.new(12334141, @item_array)
+
+    assert_equal [@item_1, @item_3], searcher.merchants_items
+  end
+
+end

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -2,6 +2,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require 'pry'
 require_relative '../lib/merchant'
+require_relative '../lib/sales_engine'
 
 class MerchantTest < Minitest::Test
 
@@ -19,5 +20,17 @@ class MerchantTest < Minitest::Test
 
   def test_a_merchant_has_a_name
     assert_equal "Turing School", @merchant.name
+  end
+
+  def test_can_look_up_a_merchants_items
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    merchant = se.merchants.find_by_id(12335747)
+    merchant_items = merchant.items
+
+    assert_equal 7, merchant_items.count
+
   end
 end


### PR DESCRIPTION
It is now possible to perform the operations listed below. This is the first half of the "starting the relationships layer" of iteration 1.

se = SalesEngine.from_csv({
  :items     => "./data/items.csv",
  :merchants => "./data/merchants.csv",
})
merchant = se.merchants.find_by_id(10)
merchant.items
# => [<item>, <item>, <item>]
